### PR TITLE
Add optional rate-limitation for AppCenter requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "resolutions": {
     "rxjs": "6.6.2"
+  },
+  "dependencies": {
+    "limiter": "^2.1.0"
   }
 }

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -68,6 +68,15 @@ export class ConfigEditor extends PureComponent<Props, State> {
     onOptionsChange({ ...options, jsonData });
   };
 
+  onReqRateLimitChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      rateLimit: parseFloat(event.target.value),
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
   render() {
     const { options } = this.props;
     const { jsonData, secureJsonFields } = options;
@@ -122,6 +131,17 @@ export class ConfigEditor extends PureComponent<Props, State> {
             value={jsonData.appName || ''}
             tooltip="Allows multiple apps separated by semicolon. You can check the available options using the query 'listApps'. Spaces will be replaced by dashes"
             placeholder="app1;myAndroidAPP;someIosApp"
+            labelWidth={10}
+            inputWidth={20}
+          />
+        </div>
+
+        <div className="gf-form">
+          <FormField
+            label="Request rate limit"
+            onChange={this.onReqRateLimitChange}
+            value={jsonData.rateLimit || '0'}
+            tooltip="Optional limit for the number of requests per second sent to AppCenter API. Can be used to avoid 429 ('Too many requests') errors. A value of 0 disables rate limitation"
             labelWidth={10}
             inputWidth={20}
           />

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,5 +1,4 @@
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
-
 import {
   DataQueryRequest,
   DataQueryResponse,
@@ -8,6 +7,8 @@ import {
   MutableDataFrame,
   FieldType,
 } from '@grafana/data';
+
+import { RateLimiter } from 'limiter';
 
 import { MyQuery, MyDataSourceOptions } from './types';
 
@@ -19,6 +20,8 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
   start: Date;
   end: Date;
   timezone: string;
+  // Rate-limiter used to limit request rate to AppCenter API to avoid HTTP status 429 ("too many requests")
+  rateLimiter?: RateLimiter;
 
   constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
     super(instanceSettings);
@@ -30,6 +33,12 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     this.start = new Date();
     this.end = new Date();
     this.timezone = 'browser';
+    if (!!instanceSettings.jsonData.rateLimit && instanceSettings.jsonData.rateLimit > 0) {
+      this.rateLimiter = new RateLimiter({
+        tokensPerInterval: instanceSettings.jsonData.rateLimit,
+        interval: 'second',
+      });
+    }
   }
 
   async query(options: DataQueryRequest<MyQuery>): Promise<DataQueryResponse> {
@@ -515,6 +524,11 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
   */
   async doRequest(url: string, queryParams: any, retry = 3): Promise<any> {
     try {
+      // Ask and wait if necessary until we are allowed to send next request
+      if (!!this.rateLimiter) {
+        const reqLeft = await this.rateLimiter.removeTokens(1);
+        console.log(`Request rate limit left ${reqLeft}`);
+      }
       const result = await getBackendSrv().datasourceRequest({
         method: 'GET',
         url: url,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,10 @@ export interface MyDataSourceOptions extends DataSourceJsonData {
   orgName: string;
   appName: string;
   key: string;
+  /**
+   * Number of requests per second
+   */
+  rateLimit?: number;
 }
 
 /**


### PR DESCRIPTION
New data source option to limit the number of requests per second
that are sent to AppCenter. Can be used to avoid 429 ('Too many requests')
errors. Uses node module 'limiter'.

This should avoid the problem described in #6 