### PR TITLE
Add new metrics "Errors per day" and "Crashes per day"

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export const TYPES = [
   'Error groups',
   'Errors',
   'Errors count',
+  'Errors per day',
+  'Crashes per day',
   'Orgs',
   'Events',
   'Event properties',
@@ -37,3 +39,8 @@ export interface MyDataSourceOptions extends DataSourceJsonData {
 export interface MySecureJsonData {
   apiKey?: string;
 }
+
+/**
+ * Error types supported by AppCenter API (unhandledError meaning crashes).
+ */
+export type ErrorType = 'all' | 'unhandledError' | 'handledError';


### PR DESCRIPTION
Those metrics can be effeciently queried with a single query to the
AppCenter backend instead of e.g. "Errors count" which potentially
needs many queries due to AppCenter API structure.

If daily interval is enough the "Crashes per day" metric could resolve #4.